### PR TITLE
Adds `indices`

### DIFF
--- a/xnumpy/core.py
+++ b/xnumpy/core.py
@@ -343,6 +343,60 @@ def anumerate(new_array, axis=0, start=0, step=1, dtype=None):
     return(an_enumeration)
 
 
+def indices(shape, dtype=None):
+    """
+        Provides a function similar to ``numpy.indices``.
+
+        Very similar to ``numpy.indices`` except for the following.
+
+        * Only returns a tuple of the index arrays for each dimension.
+        * Returns an expanded view of a ``numpy.arange``s.
+
+        This result in drastic improvements in performance in terms of
+        time, memory usage, and cache retrieval.
+
+        To get an equivalent result to ``numpy.indices``, one merely
+        need to call ``numpy.array(indices(shape, dtype=int))``.
+
+        Args:
+
+            shape(``tuple`` of ``int``s):     array to enumerate
+            dtype(``type``):                  type to use for enumerating.
+
+        Returns:
+
+            ``tuple`` of ``numpy.ndarray``s:  a tuple of index arrays.
+
+        Examples:
+
+            >>> indices((2, 3))  # doctest: +NORMALIZE_WHITESPACE
+            (array([[0, 0, 0],
+                    [1, 1, 1]]),
+             array([[0, 1, 2],
+                    [0, 1, 2]]))
+    """
+
+    try:
+        xrange
+    except NameError:
+        xrange = range
+
+    if dtype is None:
+        dtype = int
+    dtype = numpy.dtype(dtype)
+
+    grid = []
+    for i in xrange(len(shape)):
+        grid.append(expand(
+            numpy.arange(shape[i], dtype=dtype),
+            shape_before=shape[:i],
+            shape_after=shape[i+1:]
+        ))
+    grid = tuple(grid)
+
+    return(grid)
+
+
 def product(arrays):
     """
         Takes the cartesian product between the elements in each array.


### PR DESCRIPTION
Adds `indices` which behaves similar to `numpy.indices`, but is more performant on large arrays.

This is basically a consequence of design. As most usage patterns don't require a full `ndarray` with all indices, but only one for each dimension, this returns a `tuple` with an `ndarray` of indices for each dimension. Further as many of the values are duplicated, we can benefit from the functionality provided by `expand` to make an apparently full sized array that is in actuality much smaller. By using these two assumptions, we can cutdown the time to generate the indices and the memory usage drastically. For some large arrays, this can mean a few orders of magnitude improvement in both time and memory. As an added benefit, we have improved cache locality which makes operations done with these arrays much faster.

If it turns out we absolutely must have a full array with all of these indices just like `numpy.indices`, we can simply create an `ndarray` from our result. This only seems to roughly halve the construction time based on some very brief benchmarking. It is likely this is a benefit primarily from our cache locality.
