### PR TITLE
Drop spaces around keyword argument

### DIFF
--- a/xnumpy/core.py
+++ b/xnumpy/core.py
@@ -143,7 +143,7 @@ def expand(new_array,
                      [4, 4, 4, 4],
                      [5, 5, 5, 5]]]])
 
-            >>> expand(numpy.arange(6).reshape((2,3)), shape_after = (4,3))
+            >>> expand(numpy.arange(6).reshape((2,3)), shape_after=(4,3))
             array([[[[0, 0, 0],
                      [0, 0, 0],
                      [0, 0, 0],


### PR DESCRIPTION
Appears we had a minor PEP8 issue in one of the doctests where there were spaces around the `=` of the keyword argument. This fixes the issue by dropping those spaces.