### PR TITLE
Flatten `indices` default dtype check

### DIFF
--- a/xnumpy/core.py
+++ b/xnumpy/core.py
@@ -358,8 +358,7 @@ def indices(shape, dtype=None):
     except NameError:
         xrange = range
 
-    if dtype is None:
-        dtype = int
+    dtype = dtype if dtype is not None else int
     dtype = numpy.dtype(dtype)
 
     grid = []


### PR DESCRIPTION
Use a ternary expression to fill in the `dtype` to use in `indices`, if it is not already specified. Should note that `int` on Unix and Windows translate to different things. On Unix, `int` is the same as `int64`. On Windows, `int` is the same as `int32`. As such, the default type seems to be platform dependent. However, this feels less that ideal. So we may want to fix this to specific precision in the future. We should also add some tests specifically for the unspecified `dtype` case.