### PR TITLE
Use NumPy 1.13 legacy print mode in doctests

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -8,4 +8,4 @@ dependencies:
   - wheel==0.29.0
   - coverage==3.7.1
   - python-coveralls==2.5.0
-  - numpy==1.12.0
+  - numpy==1.15.4

--- a/xnumpy/core.py
+++ b/xnumpy/core.py
@@ -38,6 +38,7 @@ def expand(new_array,
                                                  tiling in various dimension.
 
         Examples:
+
             >>> a = numpy.arange(6, dtype=numpy.uint64).reshape(2,3)
             >>> a
             array([[0, 1, 2],

--- a/xnumpy/core.py
+++ b/xnumpy/core.py
@@ -39,6 +39,8 @@ def expand(new_array,
 
         Examples:
 
+            >>> numpy.set_printoptions(legacy="1.13")
+
             >>> a = numpy.arange(6, dtype=numpy.uint64).reshape(2,3)
             >>> a
             array([[0, 1, 2],


### PR DESCRIPTION
Fixes https://github.com/jakirkham/xnumpy/issues/13

To keep the doctests consistent over time, use the NumPy 1.13 legacy print mode. Should keep the maintenance effort of doctests to a minimum.